### PR TITLE
chore: migrate npm package to @goto-company

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Authenticate with Registry
         run: |
-          echo "@odpf:registry=https://registry.npmjs.org/" > .npmrc
+          echo "@goto-company:registry=https://registry.npmjs.org/" > .npmrc
           echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
         env:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Deploy 🚀
               uses: JamesIves/github-pages-deploy-action@v4
               with:
-                  TOKEN: ${{ secrets.WRITE_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   BRANCH: gh-pages # The branch the action should deploy to.
                   FOLDER: public # The folder that the build-storybook script generates files.
                   CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -22,9 +22,9 @@ jobs:
                   yarn build
                   yarn build-storybook --quiet
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@3.6.2
+              uses: JamesIves/github-pages-deploy-action@v4
               with:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TOKEN: ${{ secrets.WRITE_TOKEN }}
                   BRANCH: gh-pages # The branch the action should deploy to.
                   FOLDER: public # The folder that the build-storybook script generates files.
                   CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Apsara
 
-![build workflow](https://github.com/odpf/apsara/actions/workflows/storybook.yml/badge.svg)
+![build workflow](https://github.com/goto/apsara/actions/workflows/storybook.yml/badge.svg)
 [![License](https://img.apsaras.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-<a href="https://odpf.github.io/apsara/" target="_blank"><img src="https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg"></a>
+<a href="https://goto.github.io/apsara/" target="_blank"><img src="https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg"></a>
 
 
 Apsara 🧚‍♀️ is a React UI framework written in TypeScript on top of [Ant Design](https://ant.design/) to power the projects for Open Data Platform. Open Data Platform has a large number of enterprise-level products. With complex scenarios, designers and developers often need to respond fast due to frequent changes in product demands and concurrent R & D workflow. Many similar contents exist in the process. Through abstraction, we could obtain some stable and highly reusable components and pages on top of Ant Design.
@@ -18,18 +18,18 @@ Discover why users choose Apsara as the design system for their projects
 
 ## Usage
 
-Explore the [Storybook](https://odpf.github.io/apsara/) to learn about all the Apsara components.
+Explore the [Storybook](https://goto.github.io/apsara/) to learn about all the Apsara components.
 
 ```sh
-$ yarn add @odpf/apsara
+$ yarn add @goto-company/apsara
 # or
-$ npm install --save @odpf/apsara
+$ npm install --save @goto-company/apsara
 ```
 
 Use Apsara components inside your react project
 
 ```js
-import { Button } from "@odpf/apsara";
+import { Button } from "@goto-company/apsara";
 
 <Button size="small" type="barebone" iconName="save">
   I am using 🧚‍♀️ Apsara!
@@ -63,10 +63,10 @@ Read our contributing guide to learn about our development process, how to propo
 bugfixes and improvements, and how to build and test your changes to Apsara.
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of
-[good first issues](https://github.com/odpf/apsara/labels/good%20first%20issue) that contain bugs which have a relatively
+[good first issues](https://github.com/goto/apsara/labels/good%20first%20issue) that contain bugs which have a relatively
 limited scope. This is a great place to get started.
 
-This project exists thanks to all the [contributors](https://github.com/odpf/apsara/graphs/contributors).
+This project exists thanks to all the [contributors](https://github.com/goto/apsara/graphs/contributors).
 
 ## License
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     ],
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "0.8.2",
+    "version": "0.2.0",
     "command": {
         "version": {
             "message": "chore(release): publish %s"

--- a/packages/apsara-icons/package.json
+++ b/packages/apsara-icons/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@odpf/icons",
+    "name": "@goto-company/icons",
     "version": "0.2.0",
     "description": "Apsara icons",
     "scripts": {
@@ -18,14 +18,14 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+ssh://git@github.com/odpf/apsara.git"
+        "url": "git+ssh://git@github.com/goto/apsara.git"
     },
     "author": "",
     "license": "Apache-2.0",
     "bugs": {
-        "url": "https://github.com/odpf/apsara/issues"
+        "url": "https://github.com/goto/apsara/issues"
     },
-    "homepage": "https://github.com/odpf/apsara#readme",
+    "homepage": "https://github.com/goto/apsara#readme",
     "devDependencies": {
         "@babel/core": "^7.13.14",
         "@babel/plugin-transform-react-jsx": "^7.13.12",

--- a/packages/apsara-icons/package.json
+++ b/packages/apsara-icons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@odpf/icons",
-    "version": "0.8.2",
+    "version": "0.2.0",
     "description": "Apsara icons",
     "scripts": {
         "build": "node scripts/build.js",

--- a/packages/apsara-ui/README.md
+++ b/packages/apsara-ui/README.md
@@ -1,1 +1,1 @@
-# `@odpf/apsara`
+# `@goto-company/apsara`

--- a/packages/apsara-ui/package.json
+++ b/packages/apsara-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@odpf/apsara",
-    "version": "0.8.2",
+    "version": "0.2.0",
     "description": "A list of base components for apsara",
     "author": "Praveen Yadav <praveen.yadav@go-jek.com>",
     "license": "Apache-2.0",

--- a/packages/apsara-ui/package.json
+++ b/packages/apsara-ui/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@odpf/apsara",
+    "name": "@goto-company/apsara",
     "version": "0.2.0",
     "description": "A list of base components for apsara",
     "author": "Praveen Yadav <praveen.yadav@go-jek.com>",
@@ -27,16 +27,16 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/odpf/apsara.git"
+        "url": "git+https://github.com/goto/apsara.git"
     },
-    "homepage": "https://odpf.github.io/apsara/",
+    "homepage": "https://goto.github.io/apsara/",
     "peerDependencies": {
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@ant-design/icons": "^4.2.2",
-        "@odpf/icons": "^0.7.1-alpha.3",
+        "@goto-company/icons": "^0.1.0",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-checkbox": "^1.0.0",
         "@radix-ui/react-icons": "^1.1.1",
@@ -99,6 +99,6 @@
         "ts-import-plugin": "^1.6.6"
     },
     "bugs": {
-        "url": "https://github.com/odpf/apsara/issues"
+        "url": "https://github.com/goto/apsara/issues"
     }
 }

--- a/packages/apsara-ui/src/Button/Button.stories.mdx
+++ b/packages/apsara-ui/src/Button/Button.stories.mdx
@@ -54,7 +54,7 @@ A button means an operation (or a series of operations). Clicking a button will 
 ## Usage
 
 ```js
-import { Button } from "@odpf/apsara";
+import { Button } from "@goto-company/apsara";
 
 <Button loading type="primary">
     Click for signup

--- a/packages/apsara-ui/src/Colors/color.stories.mdx
+++ b/packages/apsara-ui/src/Colors/color.stories.mdx
@@ -30,7 +30,7 @@ import Colors from ".";
 ## Uses
 
 ```js
-import { Colors } from "@odpf/apsara";
+import { Colors } from "@goto-company/apsara";
 // Colors.light.primary[4]
 // that's it! All components will be imported with styles
 ```

--- a/packages/apsara-ui/src/Icon/Icon.tsx
+++ b/packages/apsara-ui/src/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { ThemeContext } from "styled-components";
 import { IconWrapper } from "./Icon.styles";
-import * as Icons from "@odpf/icons";
+import * as Icons from "@goto-company/icons";
 
 export type IconName = keyof typeof Icons;
 export interface CustomIconProps {

--- a/packages/apsara-ui/src/Icon/Icons.stories.mdx
+++ b/packages/apsara-ui/src/Icon/Icons.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Preview, Story, ArgsTable, IconGallery, IconItem } from "@storybook/addon-docs/blocks";
 import Icon from "./Icon";
-import * as Icons from "@odpf/icons";
+import * as Icons from "@goto-company/icons";
 export const iconsList = Object.keys(Icons);
 
 <Meta

--- a/packages/apsara-ui/src/Tag/Tag.stories.mdx
+++ b/packages/apsara-ui/src/Tag/Tag.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Preview, Canvas, Story, ArgsTable, IconGallery, IconItem } from "@storybook/addon-docs/blocks";
 import Tag from "./Tag";
-import * as Icons from "@odpf/icons";
+import * as Icons from "@goto-company/icons";
 
 export const Profile = Icons["profile"];
 

--- a/packages/apsara-ui/src/Tag/Tag.tsx
+++ b/packages/apsara-ui/src/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import React, { useState, ReactNode } from "react";
 import { StyledTag, TagWrapper } from "./Tag.styles";
-import * as Icons from "@odpf/icons";
+import * as Icons from "@goto-company/icons";
 import Colors from "../Colors";
 
 const Cross = Icons["cross"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,6 +2604,11 @@
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
 
+"@goto-company/icons@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/@goto-company/icons/-/icons-0.1.0.tgz#11a9d6537d4bc19a432924f7a40c60a4d2dbfbcd"
+  integrity sha512-8+gRNfxBQqMK40qwHCnROuc2SE39j0ypoUhkeDULhnWLDBMdg0giAKJRuumJM5Q2EISo54D/9mWc/bAvIFvIqA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -3698,11 +3703,6 @@
   integrity sha512-eZTTWJxGBon01Ra4EX86rvlMZGkU5SeJ8BtwQlsv2wEqZttpjtefLetJndZTVbJ25qFKoyKMWsRFnwlOx7ZaDQ==
   dependencies:
     "@octokit/openapi-types" "^5.3.1"
-
-"@odpf/icons@^0.7.1-alpha.3":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@odpf/icons/-/icons-0.7.5.tgz#7ec9eb2c378faae384865258faeb27e12655dc60"
-  integrity sha512-JDrmUam8etZ3rCI1st5EM7ARFtwqCpoodIzrZPwkhvjrN5MTCYIlj0Bn4M0ev9mvTPojz6rZ0j91jv4exvBF7g==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.6"


### PR DESCRIPTION
1. change all package reference to @goto-company.
2. change all github references (issues, pull, etc) to `github.com/goto` and `goto.github.com`.
3. Reset package version to `0.2.0`