### PR TITLE
Fix navbar filter bugs

### DIFF
--- a/packages/apsara-ui/src/Checkbox/Checkbox.tsx
+++ b/packages/apsara-ui/src/Checkbox/Checkbox.tsx
@@ -102,12 +102,12 @@ const CheckboxGroup = ({
                                 setSelectedValues(newSelectedValues);
                                 onChange && onChange(newSelectedValues);
                             }}
-                            id={`c${index}`}
+                            id={`${option.value}${index}`}
                             checked={selectedValues.includes(option.value || "")}
                             value={option.value}
                             {...props}
                         />
-                        <label className="checkbox_label" htmlFor={`c${index}`}>
+                        <label className="checkbox_label" htmlFor={`${option.value}${index}`}>
                             {option.label}
                         </label>
                     </div>

--- a/packages/apsara-ui/src/Sidebar/Sidebar.styles.tsx
+++ b/packages/apsara-ui/src/Sidebar/Sidebar.styles.tsx
@@ -98,7 +98,7 @@ export const NavigationItemWrapper = styled("span")<{ selected: boolean }>`
     padding: 0 0 0 14px;
     margin: 8px 0;
     height: 32px;
-    display: inline-flex;
+    display: inline;
     border-left: 2px solid transparent;
     overflow: visible;
     width: 100%;

--- a/packages/apsara-ui/src/TableV2/Table.stories.tsx
+++ b/packages/apsara-ui/src/TableV2/Table.stories.tsx
@@ -21,6 +21,7 @@ function getData(page = 1) {
         };
     });
 }
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const dataSource = getData();
 
 export const TableWithoutData = () => (

--- a/packages/apsara-ui/src/TableV2/Table.stories.tsx
+++ b/packages/apsara-ui/src/TableV2/Table.stories.tsx
@@ -21,7 +21,7 @@ function getData(page = 1) {
         };
     });
 }
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 const dataSource = getData();
 
 export const TableWithoutData = () => (


### PR DESCRIPTION
- Fix navbar links when clicking on empty space.

- When clicking on the checkbox text from the 2nd column, the 1st column checkbox was selected in the filters component.